### PR TITLE
BUG: fix bug where shadow map wasn't calculated correctly when light position changed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,6 +59,8 @@
         "streambuf": "cpp",
         "thread": "cpp",
         "cinttypes": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "xtree": "cpp",
+        "xutility": "cpp"
     }
 }

--- a/source/camera/camera.cpp
+++ b/source/camera/camera.cpp
@@ -88,3 +88,11 @@ void camera::on_input_init(GLFWwindow* _window) {
 void camera::on_scroll(double x ,double y) {
     zoom = std::min(zoom + ((float)y*zoom_speed), -1.0f);
 }
+
+int camera::window_width() {
+    return width;
+}
+
+int camera::window_height() {
+    return height;
+}

--- a/source/camera/camera.h
+++ b/source/camera/camera.h
@@ -38,6 +38,10 @@ class camera : public drawable, public inputable, public windowable {
 
         glm::vec3 get_camera_position();
         void update_window_size(int, int);
+        int window_width();
+        int window_height();
+
+
     protected:
     private:
         GLFWwindow* window;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -87,6 +87,8 @@ int main()
 
     modules::getInstance().resolve(window);
 
+    modules::getInstance().main_camera->update_window_size(primary_monitor_width,primary_monitor_height);
+
     for (auto drawable : modules::getInstance().drawables) 
     {  
         drawable->on_create();
@@ -96,8 +98,6 @@ int main()
     {  
         inputable->on_input_init(window);
     }
-
-    modules::getInstance().main_camera->update_window_size(primary_monitor_width,primary_monitor_height);
 
     auto prev_frame_time = system_clock::now();
     auto next_frame_time = prev_frame_time + framerate{1};

--- a/source/objects/icosphere/icosphere.h
+++ b/source/objects/icosphere/icosphere.h
@@ -8,6 +8,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include "../object.h"
+#include "../../shaders/shader_program.h"
 
 struct face {
     glm::vec3 points[3];
@@ -29,7 +30,9 @@ class icosphere : public object, public windowable {
 
         void on_draw_ui();
         const char* window_name();
-    protected:
+        void initialize() override;
+        void initial_render_pass() override;
+        void bind_g_buffers() override;
     private:
         std::shared_ptr<float[]> vertices;
         std::shared_ptr<unsigned int[]> indices;
@@ -45,6 +48,12 @@ class icosphere : public object, public windowable {
         std::vector<unsigned int> subdivision_index_count;
 
         void subdivide();
+        void initialize_planet_layer_map();
+
+        GLuint fbo_planet_layer_handle;
+        GLuint planet_layer_color_texture_handle;
+
+        shader_program planet_layer_shader;
 };
 
 

--- a/source/objects/object.cpp
+++ b/source/objects/object.cpp
@@ -148,7 +148,10 @@ void object::bind_uniforms(shader_program shader) {
         
 void object::on_destroy() {}
 
-void object::on_update(double delta) {}
+void object::on_update(double delta) {
+    //We update the light matrix on each frame update so that the shadows are recalculated correctly
+    update_light_matrix();
+}
 
 void object::initilize_vao() {
     auto vertices = get_vertices();
@@ -217,7 +220,10 @@ void object::initilize_shadow_map() {
     glReadBuffer(GL_NONE);
     
     glBindFramebuffer(GL_FRAMEBUFFER,0);
+    update_light_matrix();
+}
 
+void object::update_light_matrix() {
     auto normalized_light_direction = glm::normalize(light_direction);
     auto light_look_matrix = glm::lookAt(normalized_light_direction, glm::vec3(0.0f,0.0f,0.0f), glm::vec3(0.0f,1.0f,0.0f));
     auto light_projection_matrix = glm::ortho(-15.0f, 15.0f, -15.0f, 15.0f, -15.0f, 15.0f);

--- a/source/objects/object.h
+++ b/source/objects/object.h
@@ -78,6 +78,7 @@ class object : public drawable {
         void draw_debug_mesh();
         void draw_debug_normals();
         void draw_shadow_map();
+        void update_light_matrix();
         
         GLuint vao_handle;
         GLuint fbo_depth_handle;

--- a/source/objects/object.h
+++ b/source/objects/object.h
@@ -29,11 +29,11 @@ class object : public drawable {
         virtual std::shared_ptr<unsigned int[]> get_indices() = 0;
         virtual std::shared_ptr<float[]> get_normals() = 0;
         glm::mat4 get_model_matrix();
+        virtual unsigned int get_start_index() = 0;
+        virtual unsigned int get_index_count() = 0;
     protected:
         virtual unsigned int get_max_index_count() = 0;
         virtual unsigned int get_max_vertex_count() = 0;
-        virtual unsigned int get_start_index() = 0;
-        virtual unsigned int get_index_count() = 0;
         
         std::shared_ptr<camera> main_camera;
 
@@ -41,7 +41,7 @@ class object : public drawable {
         glm::mat4 translation_matrix = glm::mat4(1.0f);
         glm::mat4 rotation_matrix = glm::mat4(1.0f);
 
-        glm::vec4 diffuse_color = glm::vec4(1.0f,0.0f,0.0f,1.0f);
+        glm::vec4 diffuse_color = glm::vec4(0.6f,0.6f,0.3f,1.0f);
         unsigned int specular_exponent = 6;
         float specular_strength = 0.5f;
         float ambient_strength = 0.3f;
@@ -68,23 +68,33 @@ class object : public drawable {
         const unsigned int shadow_map_height = 2048, shadow_map_width = 2048;
         float shadow_bias_min = 0.005;
         float shadow_bias_max = 0.012;
+
+        bool show_layers = false;
+
+        virtual void initialize();
+        virtual void initial_render_pass();
+        virtual void bind_g_buffers();
+
+        void bind_uniforms(shader_program);
+        void final_render_pass(); 
+
+        GLuint vao_handle;
+
+        shader_program phong_shader;
     private:
+
         void initilize_vao(); 
         void initilize_shadow_map();
 
-        void bind_uniforms(shader_program);
-
-        void draw_phong();
+        void draw_final_render();
         void draw_debug_mesh();
         void draw_debug_normals();
         void draw_shadow_map();
         void update_light_matrix();
         
-        GLuint vao_handle;
         GLuint fbo_depth_handle;
         GLuint depth_texture_handle;
 
-        shader_program phong_shader;
         shader_program debug_mesh_shader;
         shader_program debug_normals_shader;
         shader_program shadow_shader;

--- a/source/shaders/glsl/planet/planet_color_layers_fragment.glsl
+++ b/source/shaders/glsl/planet/planet_color_layers_fragment.glsl
@@ -1,0 +1,35 @@
+#version 410
+
+in vec3 position_v;
+in vec3 normal;
+
+out vec4 fragment_color;
+
+uniform vec4 diffuse_color;
+
+void main()
+{
+    vec4 deep_ocean = vec4(0.0, 0.0, 1.0, 1.0);
+    vec4 color = deep_ocean;
+    vec3 origin = vec3(0.0, 0.0, 0.0);
+    float calc_distance = distance(origin, position_v);
+    vec4 shallow_ocean = vec4(0.2, 0.2, 0.9, 1.0);
+    vec4 grass = vec4(0.0, 1.0, 0.0, 1.0);
+    vec4 mountain = vec4(0.3, 0.13, 0.13, 1.0);
+
+    if(calc_distance > 11.0) {
+        color = mountain;
+    }
+
+    if(calc_distance > 9.0 && calc_distance < 11.0) {
+        float percentage = (11.0 - calc_distance);
+        color = (percentage * grass) + (1.0 - percentage) * mountain;
+    }
+
+    if(calc_distance > 7.0 && calc_distance < 9.0) {
+        float percentage = (10.0 - calc_distance);
+        color = (percentage * shallow_ocean) + (1.0 - percentage) * grass;
+    }
+
+    fragment_color = color;
+}

--- a/source/shaders/glsl/sphere_vertex.glsl
+++ b/source/shaders/glsl/sphere_vertex.glsl
@@ -1,6 +1,7 @@
 #version 410
 
 layout (location = 0) in vec3 vertex_position_in;
+layout (location = 1) in vec3 color;
 
 out vec3 position_v;
 


### PR DESCRIPTION
There was a bug where the light matrix used to calculate the shadow map wasn't updated each frame so as to take into account a change in the position of the light.

Attached are two comparison pictures of the result:
Incorrect shadow placement due to unchanged light matrix:
<img width="887" alt="WrongShadows" src="https://user-images.githubusercontent.com/1199488/127739541-305fb5b6-8ecb-4341-96cf-72477fae7e12.png">

With updated light matrix in the frame:
<img width="887" alt="CorrectShadows" src="https://user-images.githubusercontent.com/1199488/127739556-4e8eefdf-c74a-4fb4-8d1d-7fd856ade9c0.png">
